### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -29,11 +29,11 @@ function __one_current_folder
 end
 
 function __one_git_status_codes
-  echo (git status --porcelain ^/dev/null | sed -E 's/(^.{3}).*/\1/' | tr -d ' \n')
+  echo (git status --porcelain 2>/dev/null | sed -E 's/(^.{3}).*/\1/' | tr -d ' \n')
 end
 
 function __one_git_branch_name
-  echo (git rev-parse --abbrev-ref HEAD ^/dev/null)
+  echo (git rev-parse --abbrev-ref HEAD 2>/dev/null)
 end
 
 function __one_rainbow
@@ -71,7 +71,7 @@ function __one_git_status
 end
 
 function __git_ahead -d 'Check if there are unpulled or unpushed commits'
-  if set -l ahead_or_behind (command git rev-list --count --left-right 'HEAD...@{upstream}' ^ /dev/null)
+  if set -l ahead_or_behind (command git rev-list --count --left-right 'HEAD...@{upstream}' 2> /dev/null)
     echo $ahead_or_behind | sed 's|\s\+|\n|g'
   else
     echo 0\n0


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
